### PR TITLE
also print size of layers in the cli, fixes #5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,10 @@ Analyse dependencies of docker images.
 
 .. code::
 
-  - 65e4158d9625 Tags: ['docker.io/busybox:latest']
-     |- d4b4a1f6de61 Tags: ['bar:latest']
-       |- 29f89a1915a8 Tags: ['baz:latest']
-     |- ab8665c3e355 Tags: ['foo:latest']
+  - 65e4158d9625 Tags: ['docker.io/busybox:latest'] Size: 1.1 MiB
+     |- 8fa48410182e Tags: ['bar:latest'] Size: 1.1 MiB
+       |- 26cc8a5feb49 Tags: ['baz:latest'] Size: 1.1 MiB
+     |- 05710237af2f Tags: ['foo:latest'] Size: 1.1 MiB
 
 Usage
 -----

--- a/docktree/ImageLayer.py
+++ b/docktree/ImageLayer.py
@@ -155,14 +155,6 @@ class ImageLayer(object):
         """
         return self._size
 
-    @size.setter
-    def size(self, size):
-        """
-        set the size of the layer in bytes
-        :param size: size of the layer in bytes
-        """
-        self._size = size
-
     @size.deleter
     def size(self):
         """

--- a/docktree/ImageLayer.py
+++ b/docktree/ImageLayer.py
@@ -6,25 +6,31 @@ class ImageLayer(object):
     abstraction of a docker image layer
     """
 
-    def __init__(self, children=None, parent=None, identifier='', tags=None):
+    def __init__(self, children=None, parent=None, identifier='', tags=None, size=0):
         """
         create and initialize a new ImageLayer object
         :param children: list of children as ImageLayer objects
         :param parent: parent as ImageLayer object
         :param identifier: unique string
         :param tags: list of tags in unicode
+        :param size: size of the layer in bytes
         """
 
         self._children = children if children is not None else []
         self._parent = parent
         self._identifier = identifier
         self._tags = tags if tags is not None else []
+        self._size = size
 
     def __repr__(self):
         """
         :return: string containing a printable representation of a ImageLayer object
         """
-        return '{0} Tags: {1}'.format(self._identifier[:12], str(self._tags))
+        return '{layer_id} Tags: {layer_tag} Size: {layer_size}'.format(
+            layer_id=self._identifier[:12],
+            layer_tag=str(self._tags),
+            layer_size=_convert_size(self.size),
+        )
 
     def print_children(self, indentation=''):
         """
@@ -139,3 +145,46 @@ class ImageLayer(object):
         delete all tags
         """
         del self._tags
+
+    @property
+    def size(self):
+        """
+        return the size of the layer in bytes
+        :return: size of the layer in bytes
+        :rtype: int
+        """
+        return self._size
+
+    @size.setter
+    def size(self, size):
+        """
+        set the size of the layer in bytes
+        :param size: size of the layer in bytes
+        """
+        self._size = size
+
+    @size.deleter
+    def size(self):
+        """
+        delete the size
+        """
+        del self._size
+
+
+def _convert_size(size):
+    """
+    converts size of image to a appropriate printable format
+    :param size: size of a image in bytes
+    :return: size of a image in appropriate printable format
+    :rtype: str
+    """
+    if size <= 1024:
+        return str(size) + ' B'
+    elif size <= 1024*1024:
+        return str(round(size/1024, 1)) + ' kiB'
+    elif size <= 1024*1024*1024:
+        return str(round(size/1024/1024, 1)) + ' MiB'
+    elif size <= 1024*1024*1024*1024:
+        return str(round(size/1024/1024/1024, 1)) + ' GiB'
+    else:
+        return str(size) + ' B'

--- a/docktree/docktree.py
+++ b/docktree/docktree.py
@@ -25,7 +25,8 @@ def analyse_layers():
     for image in images:
         layer = ImageLayer(
             identifier=image['Id'],
-            tags=image['RepoTags']
+            tags=image['RepoTags'],
+            size=image['VirtualSize']
         )
         layers[image['Id']] = layer
 


### PR DESCRIPTION
`docktree-cli` now prints the size of the image-layers per default.
